### PR TITLE
Add admin dashboard page

### DIFF
--- a/client/src/Auth/AdminRoute.tsx
+++ b/client/src/Auth/AdminRoute.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+import { useAuth } from './AuthContext.tsx';
+import Login from '../Page/Login.tsx';
+
+interface AdminRouteProps {
+  children: ReactNode;
+}
+
+function getRoleFromToken(token: string): string | null {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.role ?? null;
+  } catch (e) {
+    console.error('Invalid token', e);
+    return null;
+  }
+}
+
+const AdminRoute = ({ children }: AdminRouteProps) => {
+  const { token } = useAuth();
+  if (!token) return <Login />;
+  const role = getRoleFromToken(token);
+  if (role === 'admin') {
+    return <>{children}</>;
+  }
+  return <Login />;
+};
+
+export default AdminRoute;

--- a/client/src/Page/AdminDashboard.tsx
+++ b/client/src/Page/AdminDashboard.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { PageNav } from "../component/PageNav";
+import { Tech } from "../hooks/useTech";
+
+const AdminDashboard = () => {
+  const [techniciens, setTechniciens] = useState<Tech[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchTech = async () => {
+      try {
+        const res = await fetch("http://localhost:3000/technicien");
+        const data = await res.json();
+        setTechniciens(data);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchTech();
+  }, []);
+
+  return (
+    <PageNav>
+      <div className="p-5">
+        <h1 className="text-3xl font-bold mb-4">Admin Dashboard</h1>
+        {isLoading ? (
+          <p>Chargement...</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="table w-full">
+              <thead>
+                <tr>
+                  <th>Nom</th>
+                  <th>Prénom</th>
+                  <th>Compétence</th>
+                  <th>Disponible</th>
+                </tr>
+              </thead>
+              <tbody>
+                {techniciens.map((tech) => (
+                  <tr key={tech.id}>
+                    <td>{tech.nom}</td>
+                    <td>{tech.prenom}</td>
+                    <td>{tech.competence}</td>
+                    <td>{tech.avaible ? "Oui" : "Non"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PageNav>
+  );
+};
+
+export default AdminDashboard;

--- a/client/src/component/Navbar.tsx
+++ b/client/src/component/Navbar.tsx
@@ -35,6 +35,7 @@ export const Navbar = ()=> {
           </div>
           <div className="navbar-end">
           <div className="flex gap-2">
+              <Link to="/admin" className="btn">Dashboard</Link>
               <div className="dropdown dropdown-end">
                   <Link to={"/login"}>
                   <button className="btn bg-white text-black border-[#e5e5e5]" >

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,7 +7,9 @@ import Login from "./Page/Login.tsx";
 import Register from "./Page/Register.tsx";
 import Test from "./Page/Test.tsx";
 import { Tech } from './Page/Tech.tsx'
+import AdminDashboard from './Page/AdminDashboard.tsx'
 import ProtectedRoute from "./Auth/ProtectedRoute.tsx";
+import AdminRoute from "./Auth/AdminRoute.tsx";
 import {AuthProvider} from "./Auth/AuthContext.tsx";
 
 createRoot(document.getElementById('root')!).render(
@@ -19,6 +21,7 @@ createRoot(document.getElementById('root')!).render(
                     <Route path="/login" element={<Login />} />
                     <Route path="/register" element={<Register />} />
                     <Route path="/tech" element={<Tech />} />
+                    <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />
                     <Route path="/test" element={<ProtectedRoute> <Test /> </ProtectedRoute> } />
                 </Routes>
             </BrowserRouter>


### PR DESCRIPTION
## Summary
- add AdminDashboard page with technicien table
- link to dashboard in navbar
- add protected route for /admin in router
- add AdminRoute component checking role
- add missing newline at end of Navbar file

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848c8f845688323a818667c37e88af6